### PR TITLE
fix: live-filesystem don't have password

### DIFF
--- a/hooks/in_chroot/34_setup_livefs.job
+++ b/hooks/in_chroot/34_setup_livefs.job
@@ -22,6 +22,8 @@ reconfig_livefs(){
   REAL_PASSWORD=$(echo "${DI_PASSWORD}" | base64 -d)
   echo live-filesystem live/root_password password ${REAL_PASSWORD} | debconf-set-selections
   echo live-filesystem live/root_password_again password ${REAL_PASSWORD} | debconf-set-selections
+  # compatible with old version of live-filesystem.
+  [ -f /recovery/cryptauth ] && rm -f /recovery/cryptauth
   [ -f /boot/recovery/cryptauth ] && rm -f /boot/recovery/cryptauth
   dpkg-reconfigure live-filesystem || true
 }


### PR DESCRIPTION
old version of live-filesystem is installed at /recovery while
the latest version is installed at /boot/recovery for
whole-disk-encryption's sake.