### PR TITLE
fix: remove user password for conf file

### DIFF
--- a/hooks/hook_manager.sh
+++ b/hooks/hook_manager.sh
@@ -62,9 +62,6 @@ readonly OEM_DIR
 case ${_HOOK_FILE} in
   */in_chroot/*)
     if [ "x${_IN_CHROOT}" = "xtrue" ]; then
-      # Already in chroot env.
-      # Host device is mounted at /target/deepinhost
-      CONF_FILE="/deepinhost${CONF_FILE}"
       if [ ! -f "${CONF_FILE}" ]; then
         error "Config file ${CONF_FILE} does not exists."
       fi


### PR DESCRIPTION
before_chroot/85_copy_settings_file.job复制了deepin-installer.conf到
chroot环境中，但是hook_manager.sh在in_chroot中修改了配置文件的路径，
删除这项修改，在chroot环境中仅读写系统内的配置文件.