### PR TITLE
启动后配置没有读取语言配置

### DIFF
--- a/src/ui/first_boot_setup_window.cpp
+++ b/src/ui/first_boot_setup_window.cpp
@@ -56,6 +56,7 @@ FirstBootSetupWindow::FirstBootSetupWindow(QWidget *parent)
   this->initConnections();
 
   // Read default settings.
+  language_frame_->readConf();
   system_info_frame_->readConf();
   timezone_frame_->readConf();
 }


### PR DESCRIPTION
语言页面读取配置文件后，会调用写入配置，把DI_LOCALE写到/etc/deepin-installer.conf中，hook脚本会读取配置进行设置。